### PR TITLE
Set user-agent when accessing Wikipedia API

### DIFF
--- a/controllers/wikiController.js
+++ b/controllers/wikiController.js
@@ -9,7 +9,10 @@ async function fetchAndProcessData(path) {
         page: `Wikipedia:Wikipedia_Signpost${path}`,
         format: 'json',
         redirects: 'true'
-      }
+      },
+      headers: {
+        'User-Agent': 'sinepost/0.0 (https://signpost.news/; https://github.com/jp-x-g/sinepost; User:JPxG)'
+      },
     });
     if (response.data.parse.redirects) {
       var redirs = response.data.parse.redirects;


### PR DESCRIPTION
Will now send the following user-agent header:

sinepost/0.0 (https://signpost.news/; https://github.com/jp-x-g/sinepost; User:JPxG)

This adheres to WMF User-Agent Policy, described at:

https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy

Note: I have not been able to actually run the code to test it, but it _should_ work.